### PR TITLE
[Automaton] Automaton auto-merge soak: add README validation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Test repository for the Automaton UI Developer agent.
 
 This repository is used for disposable Automaton autonomy tests.
 
+Auto-merge soak validation is enabled for disposable Automaton tests.
+
 This repo contains a simple HTML app used to validate the agent's ability to pick up GitHub issues, implement UI changes, and create pull requests.
 
 ## Current Issue


### PR DESCRIPTION
Closes #44

## What changed
```diff
 README.md | 2 ++
 1 file changed, 2 insertions(+)

```

## Approach
INFO  2026-04-26T05:07:24 +1ms service=bus type=file.watcher.updated unsubscribing INFO  2026-04-26T05:07:24 +1ms service=bus type=* unsubscribing INFO  2026-04-26T05:07:24 +0ms service=server event disconnected

## Screenshot
No screenshot (non-UI ticket or verification not run)

---
*Opened automatically by Automaton.*