### PR TITLE
[Automaton] Automaton 6h soak: add README audit note

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository is used for disposable Automaton autonomy tests.
 
 Auto-merge soak validation is enabled for disposable Automaton tests.
 
+Director decisions are audited during soak validation.
+
 This repo contains a simple HTML app used to validate the agent's ability to pick up GitHub issues, implement UI changes, and create pull requests.
 
 ## Current Issue


### PR DESCRIPTION
Closes #55

## What changed
```diff
 README.md | 2 ++
 1 file changed, 2 insertions(+)

```

## Approach
INFO  2026-04-26T05:11:47 +0ms service=bus type=file.watcher.updated unsubscribing INFO  2026-04-26T05:11:47 +2ms service=bus type=* unsubscribing INFO  2026-04-26T05:11:47 +0ms service=server event disconnected

## Screenshot
No screenshot (non-UI ticket or verification not run)

---
*Opened automatically by Automaton.*