### PR TITLE
[Automaton] Automaton 6h soak: add bounded validation README sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository is used for disposable Automaton autonomy tests.
 
 Auto-merge soak validation is enabled for disposable Automaton tests.
 
+Bounded 6h soak validation uses this disposable repository only.
+
 Director decisions are audited during soak validation.
 
 This repo contains a simple HTML app used to validate the agent's ability to pick up GitHub issues, implement UI changes, and create pull requests.


### PR DESCRIPTION
Closes #51

## What changed
```diff
 README.md | 2 ++
 1 file changed, 2 insertions(+)

```

## Approach
INFO  2026-04-26T05:22:34 +0ms service=bus type=file.watcher.updated unsubscribing INFO  2026-04-26T05:22:34 +2ms service=bus type=* unsubscribing INFO  2026-04-26T05:22:34 +0ms service=server event disconnected

## Screenshot
No screenshot (non-UI ticket or verification not run)

---
*Opened automatically by Automaton.*