### PR TITLE
[Automaton] Automaton Docker 6h soak: add README bounded sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository is used for disposable Automaton autonomy tests.
 
 Auto-merge soak validation is enabled for disposable Automaton tests.
 
+Bounded Docker soak validation uses this disposable repository only.
+
 Bounded 6h soak validation uses this disposable repository only.
 
 Director decisions are audited during soak validation.


### PR DESCRIPTION
Closes #70

## What changed
```diff
 README.md | 2 ++
 1 file changed, 2 insertions(+)

```

## Approach
INFO  2026-04-26T05:27:02 +0ms service=bus type=file.watcher.updated unsubscribing INFO  2026-04-26T05:27:02 +1ms service=bus type=* unsubscribing INFO  2026-04-26T05:27:02 +0ms service=server event disconnected

## Screenshot
No screenshot (non-UI ticket or verification not run)

---
*Opened automatically by Automaton.*