### PR TITLE
Modernize the footer copyright text (closes #87)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ function App() {
       <button id="main-btn">Docker Stable</button>
       <footer>© 2026 Copyright Test Automaton - Automaton soak</footer>
       <p className="footer-test">Disposable autonomy validation page</p>
-      <footer>built by junior-dev (auto-pickup)</footer>
+      <footer>built by junior-dev (phase 3)</footer>
     </>
   )
 }


### PR DESCRIPTION
Resolves https://github.com/ArjunSuraj/test-automaton/issues/87

Plan: Update the existing footer text in src/App.jsx to the new required copyright string.

Steps executed:
- Open src/App.jsx and locate the existing <footer> element that currently contains 'built by junior-dev (auto-pickup)'.
- Edit that footer text in place so it reads exactly 'built by junior-dev (phase 3)'.
- Do not add, remove, or duplicate any footer elements; keep the JSX structure otherwise unchanged.
- Verify the diff shows only the text change in src/App.jsx.